### PR TITLE
using less RAM in test_training.py

### DIFF
--- a/tests/primeqa/ir/dense/colbert_top/colbert/test_training.py
+++ b/tests/primeqa/ir/dense/colbert_top/colbert/test_training.py
@@ -49,9 +49,8 @@ class TestTraining(UnitTest):
         with tempfile.TemporaryDirectory() as working_dir:
             output_dir=os.path.join(working_dir, 'output_dir')
 
-
-        model_types = ['bert-base-uncased', 'xlm-roberta-base']
-        #model_types = ['xlm-roberta-base']
+        #model_types = ['bert-base-uncased', 'xlm-roberta-base']
+        model_types = ['bert-base-uncased']
 
         do_training = True
         if do_training:


### PR DESCRIPTION
ColBERT with  `xlm-roberta-base` runs out of RAM in some cases (exit code 137), removing it from the tests. 