### PR TITLE
pyarrow 9.0.0 has been observed to cause core dump in run_mrc.py afte…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ _deps = {
     "packaging~=21.3": ["install"],
     "pandas~=1.3.5": ["install"],
     "psutil~=5.9.0": ["install"],
+    "pyarrow~=8.0.0": ["install"],
     "pydata-sphinx-theme~=0.8.0": ["docs"],
     "pyserini~=0.16.0": ["install"],
     "pytest~=7.1.1": ["tests"],


### PR DESCRIPTION
pyarrow 9.0.0 has been observed to cause core dump in run_mrc.py after return from main.  Rolling back to 8.0.0 prevents this.
I have verified that a fresh condo env created in this branch will support `run_mrc.py` for training TyDI and decoding boolean pipelines.
