### PR TITLE
feat (retriever): auto-select checkpoint based on index used.

### DIFF
--- a/primeqa/components/retriever/dense.py
+++ b/primeqa/components/retriever/dense.py
@@ -40,7 +40,6 @@ class ColBERTRetriever(BaseRetriever):
         metadata={
             "name": "Checkpoint",
             "description": "Path to checkpoint",
-            "api_support": True,
         },
     )
     collection: str = field(
@@ -177,7 +176,6 @@ class DPRRetriever(BaseRetriever):
         metadata={
             "name": "Checkpoint",
             "description": "Path to checkpoint",
-            "api_support": True,
         },
     )
     collection: str = field(

--- a/primeqa/services/README.md
+++ b/primeqa/services/README.md
@@ -150,42 +150,44 @@ Create a directory under `models` and copy `pytorch_model.bin`, `config.json` an
 - Create a directory under `checkpoints` and copy the checkpoint file, e.g. a ColBERT dnn or DPR model file,  here.  
 
 - Create a directory under indexes with a unique name for the collection `<collection-name>`. Place the following files in the directory:
-  - `documents.tsv` a tsv file contains the passages that were indexed. The format is `id\ttext\ttitle`.  
-  - `index` is a directory containing the index
-  - Create `documents.sqlite` by running the following python code from `indexes/<collection-name>` directory. This file is required to fetch the document text.
+  1. `documents.tsv` a tsv file contains the passages that were indexed. The format is `id\ttext\ttitle`.  
+  2. `index` is a directory containing the index
+  3. Create `documents.sqlite` by running the following python code from `indexes/<collection-name>` directory. This file is required to fetch the document text.
 
-    ```
-    from sqlitedict import SqliteDict
-    import csv
-    
-    documents_tsv_file_path = "documents.tsv"
-    documents_sqlite_file_path = "documents.sqlite"
+      ```
+      from sqlitedict import SqliteDict
+      import csv
+      
+      documents_tsv_file_path = "documents.tsv"
+      documents_sqlite_file_path = "documents.sqlite"
 
-    with open(documents_tsv_file_path, "r", encoding="utf-8") as documents_file, SqliteDict(
-      documents_sqlite_file_path, tablename="documents"
-    ) as documents_db:
-        csv_reader = csv.DictReader(documents_file, fieldnames=["id", "text", "title"], delimiter="\t")
-        next(csv_reader)
-        for row in csv_reader:
-            assert len(row) == 3 or len(row) == 2, f'Invalid .tsv record (has to contain 2 or 3 fields): {row}'
-            documents_db[row["id"]] = {
-                "document_id": row["id"],
-                "text": row["text"],
-                "title": row["title"] if len(row) == 3 else None
-            }
-        # Commit to save documents_db
-        documents_db.commit()
-    ```
+      with open(documents_tsv_file_path, "r", encoding="utf-8") as documents_file, SqliteDict(
+        documents_sqlite_file_path, tablename="documents"
+      ) as documents_db:
+          csv_reader = csv.DictReader(documents_file, fieldnames=["id", "text", "title"], delimiter="\t")
+          next(csv_reader)
+          for row in csv_reader:
+              assert len(row) == 3 or len(row) == 2, f'Invalid .tsv record (has to contain 2 or 3 fields): {row}'
+              documents_db[row["id"]] = {
+                  "document_id": row["id"],
+                  "text": row["text"],
+                  "title": row["title"] if len(row) == 3 else None
+              }
+          # Commit to save documents_db
+          documents_db.commit()
+      ```
 
-  - Create file `information.json` and copy the following into the file:
+  4. Create the file `information.json` and add the following information into the file:
 
   ```
-    {
-      "index_id": "<collection-name>",
-      "status": "READY",
-      "engine_type": "<engine_type>",  # select one of "BM25", "ColBERT" or "DPR"
-      "checkpoint": "<checkpoint>"     # Set this to the folder name where the checkpoint is stored.
-    }
+      {
+        "index_id": "<collection-name>",
+        "status": "READY",
+        "configuration": {
+          "engine_type": "<engine_type>",  # select one of "BM25", "ColBERT" or "DPR"
+          "checkpoint": "<checkpoint>"     # Set this to the folder name where the checkpoint is stored.
+        }
+      }
   ```
 
   NOTE: `engine_type` is a now required for all Retrievers.  If you have an existing information.json file, please add this field. `checkpoint` is required for DPR and ColBERT Retrievers.

--- a/primeqa/services/constants.py
+++ b/primeqa/services/constants.py
@@ -2,8 +2,10 @@ from enum import Enum
 
 ATTR_INDEX_ID = "index_id"
 ATTR_STATUS = "status"
-ATTR_ENGINE_TYPE = "engine_type"
 ATTR_METADATA = "metadata"
+ATTR_CONFIGURATION = "configuration"
+ATTR_ENGINE_TYPE = "engine_type"
+ATTR_CHECKPOINT = "checkpoint"
 
 
 class IndexStatus(str, Enum):

--- a/primeqa/services/exceptions.py
+++ b/primeqa/services/exceptions.py
@@ -28,6 +28,7 @@ class ErrorMessages(str, Enum):
     # RETRIEVER
     INVALID_RETRIEVER = "E5001: Invalid retriever: {}. Please select one of the following pre-defined retrievers: {}"
     INDEX_UNAVAILABLE_FOR_QUERYING = 'E5002: Cannot query index with "{}" status. Please make sure index has "READY" status before querying.'
+    MISMATCHED_ENGINE_TYPE = 'E5003: Cannot query index with "{}" engine_type with {} retriever of "{}" engine type.'
 
     # INDEXER
     INVALID_INDEXER = "E6001: Invalid indexer: {}. Please select one of the following pre-defined indexers: {}"

--- a/primeqa/services/grpc_server/grpc_generated/indexer_pb2.py
+++ b/primeqa/services/grpc_server/grpc_generated/indexer_pb2.py
@@ -17,7 +17,7 @@ from . import parameter_pb2 as parameter__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rindexer.proto\x12\x05index\x1a\x0fparameter.proto\x1a\x1cgoogle/protobuf/struct.proto\"G\n\x07Indexer\x12\x12\n\nindexer_id\x18\x01 \x01(\t\x12(\n\nparameters\x18\x02 \x03(\x0b\x32\x14.parameter.Parameter\"\x14\n\x12GetIndexersRequest\"7\n\x13GetIndexersResponse\x12 \n\x08indexers\x18\x01 \x03(\x0b\x32\x0e.index.Indexer\"<\n\x08\x44ocument\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocument_id\x18\x02 \x01(\t\x12\r\n\x05title\x18\x03 \x01(\t\"\x98\x01\n\x14GenerateIndexRequest\x12\x1f\n\x07indexer\x18\x01 \x01(\x0b\x32\x0e.index.Indexer\x12\"\n\tdocuments\x18\x02 \x03(\x0b\x32\x0f.index.Document\x12\x10\n\x08index_id\x18\x03 \x01(\t\x12)\n\x08metadata\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"M\n\x15GenerateIndexResponse\x12\x10\n\x08index_id\x18\x01 \x01(\t\x12\"\n\x06status\x18\x02 \x01(\x0e\x32\x12.index.IndexStatus\")\n\x15GetIndexStatusRequest\x12\x10\n\x08index_id\x18\x01 \x01(\t\"9\n\x13IndexStatusResponse\x12\"\n\x06status\x18\x01 \x01(\x0e\x32\x12.index.IndexStatus\"(\n\x11GetIndexesRequest\x12\x13\n\x0b\x65ngine_type\x18\x01 \x01(\t\"s\n\x10IndexInformation\x12\x10\n\x08index_id\x18\x01 \x01(\t\x12\"\n\x06status\x18\x02 \x01(\x0e\x32\x12.index.IndexStatus\x12)\n\x08metadata\x18\x03 \x01(\x0b\x32\x17.google.protobuf.Struct\">\n\x12GetIndexesResponse\x12(\n\x07indexes\x18\x01 \x03(\x0b\x32\x17.index.IndexInformation*H\n\x0bIndexStatus\x12\t\n\x05READY\x10\x00\x12\x0c\n\x08INDEXING\x10\x01\x12\x13\n\x0f\x44OES_NOT_EXISTS\x10\x02\x12\x0b\n\x07\x43ORRUPT\x10\x03\x32\xb4\x02\n\x0fIndexingService\x12\x44\n\x0bGetIndexers\x12\x19.index.GetIndexersRequest\x1a\x1a.index.GetIndexersResponse\x12L\n\rGenerateIndex\x12\x1b.index.GenerateIndexRequest\x1a\x1c.index.GenerateIndexResponse(\x01\x12J\n\x0eGetIndexStatus\x12\x1c.index.GetIndexStatusRequest\x1a\x1a.index.IndexStatusResponse\x12\x41\n\nGetIndexes\x12\x18.index.GetIndexesRequest\x1a\x19.index.GetIndexesResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rindexer.proto\x12\x05index\x1a\x0fparameter.proto\x1a\x1cgoogle/protobuf/struct.proto\"G\n\x07Indexer\x12\x12\n\nindexer_id\x18\x01 \x01(\t\x12(\n\nparameters\x18\x02 \x03(\x0b\x32\x14.parameter.Parameter\"\x14\n\x12GetIndexersRequest\"7\n\x13GetIndexersResponse\x12 \n\x08indexers\x18\x01 \x03(\x0b\x32\x0e.index.Indexer\"<\n\x08\x44ocument\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocument_id\x18\x02 \x01(\t\x12\r\n\x05title\x18\x03 \x01(\t\"\xbc\x01\n\x14GenerateIndexRequest\x12\x1f\n\x07indexer\x18\x01 \x01(\x0b\x32\x0e.index.Indexer\x12\"\n\tdocuments\x18\x02 \x03(\x0b\x32\x0f.index.Document\x12\x15\n\x08index_id\x18\x03 \x01(\tH\x00\x88\x01\x01\x12.\n\x08metadata\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x01\x88\x01\x01\x42\x0b\n\t_index_idB\x0b\n\t_metadata\"M\n\x15GenerateIndexResponse\x12\x10\n\x08index_id\x18\x01 \x01(\t\x12\"\n\x06status\x18\x02 \x01(\x0e\x32\x12.index.IndexStatus\")\n\x15GetIndexStatusRequest\x12\x10\n\x08index_id\x18\x01 \x01(\t\"9\n\x13IndexStatusResponse\x12\"\n\x06status\x18\x01 \x01(\x0e\x32\x12.index.IndexStatus\"(\n\x11GetIndexesRequest\x12\x13\n\x0b\x65ngine_type\x18\x01 \x01(\t\"\xb5\x01\n\x10IndexInformation\x12\x10\n\x08index_id\x18\x01 \x01(\t\x12\"\n\x06status\x18\x02 \x01(\x0e\x32\x12.index.IndexStatus\x12.\n\rconfiguration\x18\x03 \x01(\x0b\x32\x17.google.protobuf.Struct\x12.\n\x08metadata\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x88\x01\x01\x42\x0b\n\t_metadata\">\n\x12GetIndexesResponse\x12(\n\x07indexes\x18\x01 \x03(\x0b\x32\x17.index.IndexInformation*H\n\x0bIndexStatus\x12\t\n\x05READY\x10\x00\x12\x0c\n\x08INDEXING\x10\x01\x12\x13\n\x0f\x44OES_NOT_EXISTS\x10\x02\x12\x0b\n\x07\x43ORRUPT\x10\x03\x32\xb4\x02\n\x0fIndexingService\x12\x44\n\x0bGetIndexers\x12\x19.index.GetIndexersRequest\x1a\x1a.index.GetIndexersResponse\x12L\n\rGenerateIndex\x12\x1b.index.GenerateIndexRequest\x1a\x1c.index.GenerateIndexResponse(\x01\x12J\n\x0eGetIndexStatus\x12\x1c.index.GetIndexStatusRequest\x1a\x1a.index.IndexStatusResponse\x12\x41\n\nGetIndexes\x12\x18.index.GetIndexesRequest\x1a\x19.index.GetIndexesResponseb\x06proto3')
 
 _INDEXSTATUS = DESCRIPTOR.enum_types_by_name['IndexStatus']
 IndexStatus = enum_type_wrapper.EnumTypeWrapper(_INDEXSTATUS)
@@ -119,8 +119,8 @@ _INDEXINGSERVICE = DESCRIPTOR.services_by_name['IndexingService']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _INDEXSTATUS._serialized_start=844
-  _INDEXSTATUS._serialized_end=916
+  _INDEXSTATUS._serialized_start=947
+  _INDEXSTATUS._serialized_end=1019
   _INDEXER._serialized_start=71
   _INDEXER._serialized_end=142
   _GETINDEXERSREQUEST._serialized_start=144
@@ -130,19 +130,19 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DOCUMENT._serialized_start=223
   _DOCUMENT._serialized_end=283
   _GENERATEINDEXREQUEST._serialized_start=286
-  _GENERATEINDEXREQUEST._serialized_end=438
-  _GENERATEINDEXRESPONSE._serialized_start=440
-  _GENERATEINDEXRESPONSE._serialized_end=517
-  _GETINDEXSTATUSREQUEST._serialized_start=519
-  _GETINDEXSTATUSREQUEST._serialized_end=560
-  _INDEXSTATUSRESPONSE._serialized_start=562
-  _INDEXSTATUSRESPONSE._serialized_end=619
-  _GETINDEXESREQUEST._serialized_start=621
-  _GETINDEXESREQUEST._serialized_end=661
-  _INDEXINFORMATION._serialized_start=663
-  _INDEXINFORMATION._serialized_end=778
-  _GETINDEXESRESPONSE._serialized_start=780
-  _GETINDEXESRESPONSE._serialized_end=842
-  _INDEXINGSERVICE._serialized_start=919
-  _INDEXINGSERVICE._serialized_end=1227
+  _GENERATEINDEXREQUEST._serialized_end=474
+  _GENERATEINDEXRESPONSE._serialized_start=476
+  _GENERATEINDEXRESPONSE._serialized_end=553
+  _GETINDEXSTATUSREQUEST._serialized_start=555
+  _GETINDEXSTATUSREQUEST._serialized_end=596
+  _INDEXSTATUSRESPONSE._serialized_start=598
+  _INDEXSTATUSRESPONSE._serialized_end=655
+  _GETINDEXESREQUEST._serialized_start=657
+  _GETINDEXESREQUEST._serialized_end=697
+  _INDEXINFORMATION._serialized_start=700
+  _INDEXINFORMATION._serialized_end=881
+  _GETINDEXESRESPONSE._serialized_start=883
+  _GETINDEXESRESPONSE._serialized_end=945
+  _INDEXINGSERVICE._serialized_start=1022
+  _INDEXINGSERVICE._serialized_end=1330
 # @@protoc_insertion_point(module_scope)

--- a/primeqa/services/grpc_server/protos/indexer.proto
+++ b/primeqa/services/grpc_server/protos/indexer.proto
@@ -51,8 +51,8 @@ message Document {
 message GenerateIndexRequest {
     Indexer indexer = 1;
     repeated Document documents = 2;
-    string index_id = 3;
-    google.protobuf.Struct metadata = 4;
+    optional string index_id = 3;
+    optional google.protobuf.Struct metadata = 4;
 }
 
 enum IndexStatus {
@@ -82,7 +82,8 @@ message GetIndexesRequest {
 message IndexInformation {
     string index_id = 1;
     IndexStatus status = 2;
-    google.protobuf.Struct metadata = 3;
+    google.protobuf.Struct configuration = 3;
+    optional google.protobuf.Struct metadata = 4;
 }
 
 message GetIndexesResponse {

--- a/primeqa/services/rest_server/data_models.py
+++ b/primeqa/services/rest_server/data_models.py
@@ -107,4 +107,5 @@ class IndexInformation(BaseModel):
         IndexStatus.DOES_NOT_EXISTS,
         IndexStatus.CORRUPT,
     ]
+    configuration: Dict[str, Any]
     metadata: Union[Dict[str, Any], None] = None


### PR DESCRIPTION
# Pull Request      

## What does this PR do?

In case of service based use, `retrieve` endpoint doesn't need checkpoint information as it is inferred based on index information. 

## Description

- Modified index information to store `checkpoint` related information under `configuration` field. 
- Moved `engine_type` under same `configuration` field in index information.
- In `retrieve` API call, checkpoint used by retriever is inferred used value in `configuration` in index information.

**TODOs**
- Need to update README to reflect changed structure of `information.json` in each index directory.
