### PR TITLE
Use DPRQuestionEncoderTokenizerFast for DPR searcher.

### DIFF
--- a/primeqa/ir/dense/dpr_top/dpr/dpr_util.py
+++ b/primeqa/ir/dense/dpr_top/dpr/dpr_util.py
@@ -1,4 +1,4 @@
-from transformers import (DPRQuestionEncoder, RagTokenizer, DPRQuestionEncoderTokenizer, RagTokenForGeneration)
+from transformers import (DPRQuestionEncoder, RagTokenizer, DPRQuestionEncoderTokenizer, DPRQuestionEncoderTokenizerFast, RagTokenForGeneration)
 import logging
 from typing import List, Union, Tuple
 from primeqa.ir.dense.dpr_top.torch_util.hypers_base import HypersBase
@@ -13,7 +13,7 @@ class DPROptions(HypersBase):
     def _post_init(self):
         super()._post_init()
 
-def tokenize_queries(tokenizer: Union[RagTokenizer, DPRQuestionEncoderTokenizer],
+def tokenize_queries(tokenizer: Union[RagTokenizer, DPRQuestionEncoderTokenizer, DPRQuestionEncoderTokenizerFast],
                      queries: Union[List[str], List[Tuple[str, str]]], *, max_length: int):
     """
 
@@ -53,7 +53,7 @@ def tokenize_queries(tokenizer: Union[RagTokenizer, DPRQuestionEncoderTokenizer]
     return model_inputs
 
 
-def queries_to_vectors(tokenizer: Union[RagTokenizer, DPRQuestionEncoderTokenizer], question_encoder,
+def queries_to_vectors(tokenizer: Union[RagTokenizer, DPRQuestionEncoderTokenizer, DPRQuestionEncoderTokenizerFast], question_encoder,
                        queries: Union[List[str], List[Tuple[str, str]]], *, max_query_length=None):
     """
 

--- a/primeqa/ir/dense/dpr_top/dpr/searcher.py
+++ b/primeqa/ir/dense/dpr_top/dpr/searcher.py
@@ -71,7 +71,7 @@ class DPRSearcher():
         self.qencoder = DPRQuestionEncoder.from_pretrained(self.opts.qry_encoder_name_or_path)
         self.qencoder = self.qencoder.to(self.device)
         self.qencoder.eval()
-        self.tokenizer = DPRQuestionEncoderTokenizer.from_pretrained(self.opts.qry_encoder_name_or_path)
+        self.tokenizer = DPRQuestionEncoderTokenizerFast.from_pretrained(self.opts.qry_encoder_name_or_path)
 
         if self.opts.rescore_only:
             # since this is re-ranker only mode we don't need an index.


### PR DESCRIPTION
Use DPRQuestionEncoderTokenizerFast for DPR searcher.

1. Currently In train/index modules, tokenizers are loaded as DPRQuestionEncoderTokenizerFast, but in search module, they are loaded as DPRQuestionEncoderTokenizer.

2. Sentence-piece tokenizer only works as HuggingFace fast tokenizer, i.e. DPRQuestionEncoderTokenizerFast.

3. The upgrade from DPRQuestionEncoderTokenizer to DPRQuestionEncoderTokenizerFast for DPR searcher won't affect existing DPR models which were built on BPE/word-piece tokenizers, e.g. those based on IBM slate models. These tokenizers return same results when loaded as DPRQuestionEncoderTokenizerFast or DPRQuestionEncoderTokenizer.

# Pull Request      

## What does this PR do?

```Closes #(issue)```       

Notes:
- Replace `(issue)` **above** ↑↑↑ with the issue this PR closes to automatically link the two.
This must be done when the PR is created.
- Add multiple `Closes #(issue)` as needed.
- If this PR is work towards but does not close an issue, simply tag the issue without mentioning `Closes`.

## Description

**Describe** the changes proposed by this PR below to give the reviewer context below ↓↓↓

```(description)```     

### Request Review

Be sure to **request a review** from one or more reviewers (unless the PR is to an unprotected branch).

## Versioning

When opening a PR to make changes to PrimeQA (i.e. `primeqa/`) master, be sure to increment the version following
[semantic versioning](https://semver.org/).  The VERSION is stored [here](https://github.com/primeqa/primeqa/blob/main/VERSION) 
and is incremented using `bump2version {patch,minor,major}` as described in the (development guide documentation)[development.html].

 - [ ] Have you updated the VERSION?
 - [ ] Or does this PR not change the `primeqa` package or was not into master?

After pulling in changes from master to an existing PR, ensure the VERSION is updated appropriately.
This may require bumping the version again if it has been previously bumped.

If you're not quite ready yet to post a PR for review, feel free to open a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

## Releases

### After Merging
If merging into master and VERSION was updated, after this PR is merged:
- [ ] [Create a release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) from the master with version equal to [VERSION](https://github.com/primeqa/primeqa/blob/main/VERSION)
- [ ] Not merging to master or VERSION not updated

### Checklist

Review the following and mark as completed:
- [ ] [Tag an issue or issues](#what-does-this-pr-do) this PR addresses.
- [ ] Added [description](#description) of changes proposed.
- [ ] Review requested as [appropriate](#request-review).
- [ ] Version bumped as [appropriate](#Versioning).
- [ ] New classes, methods, and functions documented.
- [ ] Documentation for modified code is updated.
- [ ] Built documentation to confirm it renders as expected (see [here](development.md)).
- [ ] Code cleaned up and commented out code removed.
- [ ] Tests added to ensure all functionalities tested at >= 60% unit test coverage (see [here](development.md)).
- [ ] Code cleaned up and commented out code removed.
- [ ] Release created [as needed](#after-merging) after merging.